### PR TITLE
fix: dont add kill if the player committed suicide

### DIFF
--- a/src/utils/collectGameData.js
+++ b/src/utils/collectGameData.js
@@ -12,9 +12,11 @@ function colectGameData(expression, gameInfo) {
     var killer = getKillerPlayer(expression);
     var killed = getKilledPlayer(expression);
 
-    // Add killer players and kills on array
+    // Add players on array
 	gameInfo = addPlayers(killer, gameInfo);
-	if(killer !== "<world>") {
+
+	// Add a kill if the killer is different from <world> or if the player did not commit suicide
+	if(killer !== "<world>" && killer !== killed) {
 		gameInfo = addKillers(killer, gameInfo);
 	}
 


### PR DESCRIPTION
**Description**

If the player commits a suicide, a kill is not added to him.

**Evidences**

![Captura de Tela 2021-05-24 às 21 09 39](https://user-images.githubusercontent.com/75806677/119421118-5c25c580-bcd4-11eb-991d-b5dc03c38154.png)

**How to test**

Run the command: **node index.js**